### PR TITLE
Stop function and no overwrite active minibuffer

### DIFF
--- a/symon.el
+++ b/symon.el
@@ -89,6 +89,11 @@ BEFORE calling `symon-initialize'.*"
   "like `make-ring' but INIT can be specified."
   (cons 0 (cons size (make-vector size init))))
 
+(defun symon-stop ()
+  (interactive)
+  "stop symon system monitor"
+  (cancel-function-timers 'symon-display))
+
 (defun symon-initialize ()
   "setup symon system monitor."
   (interactive)

--- a/symon.el
+++ b/symon.el
@@ -128,14 +128,15 @@ BEFORE calling `symon-initialize'.*"
         (cpu (ring-ref symon--cpu-status 0))
         (battery (ring-ref symon--battery-status 0))
         (message-log-max nil))    ; do not insert to *Messages* buffer
-    (message
-     (concat "MEM:" (if (not (integerp memory)) "N/A " (format "%2d%%%% " memory))
-             (when (and (integerp swap) (> swap 0)) (format "(%dMB Swapped) " swap))
-             (propertize " " 'display (symon--make-sparkline symon--memory-status)) " "
-             "CPU:" (if (not (integerp cpu)) "N/A " (format "%2d%%%% " cpu))
-             (propertize " " 'display (symon--make-sparkline symon--cpu-status)) " "
-             "BAT:" (if (not (integerp battery)) "N/A " (format "%d%%%% " battery))
-             (propertize " " 'display (symon--make-sparkline symon--battery-status)))))
+    (if (not (active-minibuffer-window))
+        (message
+         (concat "MEM:" (if (not (integerp memory)) "N/A " (format "%2d%%%% " memory))
+                 (when (and (integerp swap) (> swap 0)) (format "(%dMB Swapped) " swap))
+                 (propertize " " 'display (symon--make-sparkline symon--memory-status)) " "
+                 "CPU:" (if (not (integerp cpu)) "N/A " (format "%2d%%%% " cpu))
+                 (propertize " " 'display (symon--make-sparkline symon--cpu-status)) " "
+                 "BAT:" (if (not (integerp battery)) "N/A " (format "%d%%%% " battery))
+                 (propertize " " 'display (symon--make-sparkline symon--battery-status))))))
   (setq symon--active t))
 
 (defun symon--redisplay ()


### PR DESCRIPTION
Hi

love this functionality. As I tend to dither when in the minibuffer I found symon sometimes overwrote what I was doing if I didn't think before *refreshrate* seconds kicked in.

I also added a function to stop.

Make of it what you will. I appreciate you writing this functionality.