### PR TITLE
Prevent division by zero error

### DIFF
--- a/symon.el
+++ b/symon.el
@@ -163,12 +163,12 @@ BEFORE enabling `symon-mode'.*"
              (lst (mapcar 'read (split-string (match-string 1 str) nil t)))
              (total (apply '+ lst))
              (idle (nth 3 lst)))
-        (setq symon--default-linux-last-cpu-ticks (cons total idle))
         (if symon--default-linux-last-cpu-ticks
             (let ((total-diff (- total (car symon--default-linux-last-cpu-ticks)))
                   (idle-diff (- idle (cdr symon--default-linux-last-cpu-ticks))))
               (symon-commit-status 'cpu (/ (* (- total-diff idle-diff) 100) total-diff)))
-          (symon-commit-status 'cpu nil)))
+          (symon-commit-status 'cpu nil))
+        (setq symon--default-linux-last-cpu-ticks (cons total idle)))
     (symon-commit-status 'cpu nil))
   ;; Memory / Swap
   (if (file-exists-p "/proc/meminfo")


### PR DESCRIPTION
I get a division by zero error when first starting symon. It looks like you recently changed this logic and maybe haven't tested with clean state? I'm not too familiar with the code but this looks to fix it. 

The first time through this logic `idle` will be the same as the cdr of `symon--default-linux-last-cpu-ticks` so you get a division by zero.