### PR TITLE
Add an option to center the display in the minibuffer

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -71,6 +71,8 @@ You need to restart =symon-mode= in order to reflect changes of these
 
     [[file:img/gridded.png]]
 
+- =symon-center-display= :: Center the display in the minibuffer.
+
 ** Preconfigured Monitors
 
 - GNU/Linux

--- a/symon.el
+++ b/symon.el
@@ -18,7 +18,7 @@
 
 ;; Author: zk_phi
 ;; URL: http://hins11.yu-yake.com/
-;; Version: 1.1.2
+;; Version: 1.1.3
 
 ;;; Commentary:
 
@@ -38,13 +38,14 @@
 ;; 1.1.0 add option symon-sparkline-thickness
 ;; 1.1.1 add symon-windows-page-file-monitor
 ;; 1.1.2 add darwin support (mac os x)
+;; 1.1.3 add option symon-center-display
 
 ;;; Code:
 
 (require 'battery)
 (require 'ring)
 
-(defconst symon-version "1.1.2")
+(defconst symon-version "1.1.3")
 
 (defgroup symon nil
   "tiny graphical system monitor"
@@ -108,6 +109,10 @@ smaller. *set this option BEFORE enabling `symon-mode'.*"
 
 (defcustom symon-sparkline-type 'symon-sparkline-type-gridded
   "type of sparklines."
+  :group 'symon)
+
+(defcustom symon-center-display nil
+  "center the display"
   :group 'symon)
 
 ;; some darwin builds cannot render xbm images (foreground color is
@@ -630,6 +635,17 @@ while(1)                                                            \
 (define-symon-monitor symon-current-time-monitor
   :display (format-time-string "%H:%M"))
 
+;;   + misc display
+
+(defun symon--center-minibuffer (width)
+  "Center align the minibuffer content"
+  (let ((lmargin (- (/ (frame-width) 2) (/ width 2))))
+    (set-window-margins (minibuffer-window) lmargin)))
+
+(defun symon--uncenter-minibuffer ()
+  "Left align the minibuffer content"
+    (set-window-margins (minibuffer-window) 0))
+
 ;; + symon core
 
 (defvar symon--cleanup-fns    nil)
@@ -663,6 +679,8 @@ while(1)                                                            \
   "activate symon display."
   (interactive)
   (unless (active-minibuffer-window)
+    (when symon-center-display
+      (symon--center-minibuffer 80))
     (let* ((message-log-max nil))   ; do not insert to *Messages* buffer
       (message "%s" (apply 'concat (mapcar 'funcall symon--display-fns))))
     (setq symon--display-active t)))
@@ -673,6 +691,8 @@ while(1)                                                            \
 
 (defun symon--display-end ()
   "deactivate symon display."
+  (when symon-center-display
+    (symon--uncenter-minibuffer))
   (setq symon--display-active nil))
 
 ;; + provide


### PR DESCRIPTION
Hi @zk-phi ,

I added an option to center the display of the minibuffer when symon displays its graphs.
I don't know if you wish to integrate this kind of feature, but it was a request on reddit. Up to you to merge it or not, of course.

Next, I'll deal with the Fish shell issue on Mac OS X.

Thanks !
