### PR TITLE
Add in cl-lib dependency (fix #40)

### DIFF
--- a/symon.el
+++ b/symon.el
@@ -44,6 +44,7 @@
 
 (require 'battery)
 (require 'ring)
+(require 'cl-lib)
 
 (defconst symon-version "1.2.0")
 

--- a/symon.el
+++ b/symon.el
@@ -690,7 +690,7 @@ while(1)                                                            \
           symon--total-page-num (length symon-monitors)
           symon--timer-objects
           (list (run-with-timer 0 symon-refresh-rate 'symon--redisplay)
-                (run-with-idle-timer symon-delay t 'symon-display)))
+                (run-with-idle-timer symon-delay symon-refresh-rate 'symon-display)))
     (add-hook 'pre-command-hook 'symon--display-end)
     (add-hook 'kill-emacs-hook 'symon--cleanup)))
 


### PR DESCRIPTION
This patch fixes the error where (void-variable memavailable) appears in the minibuffer repeatedly instead of symon; the error occurs because cl-lib is
needed to use cl-destructuring bind, and cl-lib is not explicitly declared. 